### PR TITLE
Add minimal Flask prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Paper2Code
+
+This project explores automated extraction of code from research papers. See [UI_UX_Flow.md](UI_UX_Flow.md) for the proposed user interface and output design.
+
+A minimal web prototype is included using [Flask](https://flask.palletsprojects.com/). To run the app locally:
+
+```bash
+pip install flask PyPDF2
+python app.py
+```
+
+Then visit `http://localhost:5000` to upload a PDF and view the generated placeholders.

--- a/UI_UX_Flow.md
+++ b/UI_UX_Flow.md
@@ -1,0 +1,103 @@
+# Paper2Code — UI/UX Flow & Output Blueprint
+
+## 1. User Journey: Step by Step
+
+### A. Home / Landing Page
+- **Header**: App name/logo "Paper2Code" and short tagline "Turn research papers into working code." 
+- **Call to Action**: Central "Upload your research paper (PDF)" box/button.
+- **Supported models**: display tags such as "Powered by Gemini, DeepSeek, Ollama".
+- **Optional**: Info icon for "How it works".
+
+### B. PDF Upload
+1. User clicks *Upload*, selects a PDF from the device.
+2. Show progress indicator or spinner "Uploading…".
+3. On errors (file too large or wrong format) display a clear message.
+4. On success, move to the processing stepper.
+
+### C. Processing State (Stepper Progress Flow)
+- **Visual stepper** showing:
+  1. PDF Uploaded
+  2. Text Extracted
+  3. Methodology Identified
+  4. Pseudocode Generated
+  5. Python Code Generated
+  6. Test Data Created
+  7. Results Ready!
+- Highlight the active step with a spinner, mark completed steps with a check.
+- Optionally show real-time logs or "AI is thinking…" animations.
+
+### D. Results Display (Tabbed Output)
+Once the LLM finishes, show four tabs:
+1. **Methodology** – summarized in plain language with a copy button.
+2. **Pseudocode** – numbered steps, clear indentation, copy button.
+3. **Python Code** – syntax-highlighted, copy and download button.
+4. **Test Data & Output** – test code with optional sample output, copy button.
+
+### E. Actions/Enhancements
+- **Download All** sections as a Notebook, Markdown, or ZIP.
+- **Retry** with optional prompt tweak.
+- **Switch LLM** backend.
+- **New Upload** to restart.
+- **Feedback** widget for usefulness.
+
+### F. Error/Edge Cases
+- PDF too short/unreadable: "Could not extract sufficient text."
+- LLM API issues: "Provider overloaded. Please try again later." 
+- Section not found: tab displays "Section not generated—try regenerating or check your PDF."
+
+## 2. Detailed UI Layout
+### A. Desktop Web Example
+```
++----------------------------------------------------------+
+| Paper2Code   [logo]                          [About]     |
++----------------------------------------------------------+
+|    "Turn research papers into working code."             |
+|                                                          |
+|  [Upload PDF]                                            |
+|   (or drag & drop)                                       |
+|                                                          |
+|   [ Model: Gemini ▼ ]   [Try Demo PDF]                   |
+|----------------------------------------------------------|
+|  (Stepper: 1..2..3..4..5..6..7..)                        |
+|----------------------------------------------------------|
+|  [Tab: Methodology] [Tab: Pseudocode] [Tab: Code] [Tab: Test Data]   |
+|                                                          |
+|   [Code block / text output]                             |
+|   [Copy]    [Download]                                   |
+|----------------------------------------------------------|
+|  [New Upload]         [Feedback]                         |
++----------------------------------------------------------+
+```
+
+### B. Mobile/Tablet
+- Tabs become collapsible accordion sections.
+- Sticky upload or "new" button.
+- Progress steps shown as a vertical stack.
+
+## 3. Output Examples at Each Stage
+| Stage | Output Example |
+|-------|----------------|
+| Methodology | "This paper introduces a novel transformer-based architecture for ..." |
+| Pseudocode | `1. Initialize weights\n2. For each epoch:\n  a. Forward pass\n  b. Compute loss\n  c. Backprop and update weights` |
+| Python Code | `import torch\ndef train(X, y):\n    ...` |
+| Test Data | `# Example usage\nX_test = ...\nmodel.predict(X_test)\nOutput:\n[0.7, 0.2, 0.8]` |
+
+## 4. User Experience Enhancements
+- Optimistic UI placeholders while generating.
+- Progressive disclosure for advanced settings.
+- Accessibility support: keyboard navigation, screen reader labels.
+- Dark mode theming.
+
+## 5. Best Practices & Future Proofing
+- Never expose API keys in the browser. Sanitize uploads.
+- Provide a feedback loop for failed generations.
+- Design modularly to add more models or output formats.
+
+## 6. Complete Flow
+1. Visit site → Welcome → Upload PDF.
+2. Stepper shows progress: "Extracting…", "Generating code…".
+3. Tabs fill with Methodology, Pseudocode, Python, Test Data.
+4. User can copy, download, or run the code.
+5. Errors are shown inline.
+6. User can start over with a new paper or model.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,72 @@
+from flask import Flask, render_template, request
+from werkzeug.utils import secure_filename
+import os
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = 'uploads'
+
+# Ensure the upload folder exists
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+
+
+def extract_text_from_pdf(file_path: str) -> str:
+    """Placeholder PDF text extraction."""
+    try:
+        from PyPDF2 import PdfReader
+        reader = PdfReader(file_path)
+        return "\n".join(page.extract_text() or "" for page in reader.pages)
+    except Exception:
+        return ""
+
+
+def identify_methodology(text: str) -> str:
+    """Placeholder for methodology extraction."""
+    if not text:
+        return "Could not extract sufficient text."
+    # Here you would call an LLM. For now, return a dummy summary.
+    return "This paper proposes a placeholder method for demonstration purposes."
+
+
+def generate_pseudocode(text: str) -> str:
+    """Return example pseudocode based on the text."""
+    return """1. Parse the input paper\n2. Identify key algorithms\n3. Generate pseudocode"""
+
+
+def generate_python_code(text: str) -> str:
+    """Return example Python code."""
+    return """def demo():\n    pass"""
+
+
+def generate_test_data(text: str) -> str:
+    return """# Example test data\ninput_data = []"""
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        pdf = request.files.get('pdf')
+        if not pdf:
+            return render_template('index.html', error='Please upload a PDF file.')
+        filename = secure_filename(pdf.filename)
+        file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        pdf.save(file_path)
+
+        text = extract_text_from_pdf(file_path)
+        methodology = identify_methodology(text)
+        pseudocode = generate_pseudocode(text)
+        python_code = generate_python_code(text)
+        test_data = generate_test_data(text)
+
+        return render_template(
+            'result.html',
+            methodology=methodology,
+            pseudocode=pseudocode,
+            python_code=python_code,
+            test_data=test_data,
+        )
+
+    return render_template('index.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Paper2Code</title>
+</head>
+<body>
+<h1>Paper2Code</h1>
+<p>Turn research papers into working code.</p>
+{% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+<form method="post" enctype="multipart/form-data">
+    <input type="file" name="pdf" accept="application/pdf" required>
+    <button type="submit">Upload PDF</button>
+</form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Paper2Code Results</title>
+</head>
+<body>
+<h1>Results</h1>
+<ul>
+    <li><a href="#methodology">Methodology</a></li>
+    <li><a href="#pseudocode">Pseudocode</a></li>
+    <li><a href="#code">Python Code</a></li>
+    <li><a href="#test">Test Data</a></li>
+</ul>
+<h2 id="methodology">Methodology</h2>
+<pre>{{ methodology }}</pre>
+<h2 id="pseudocode">Pseudocode</h2>
+<pre>{{ pseudocode }}</pre>
+<h2 id="code">Python Code</h2>
+<pre>{{ python_code }}</pre>
+<h2 id="test">Test Data</h2>
+<pre>{{ test_data }}</pre>
+<a href="/">New Upload</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask web app for Paper2Code
- create basic templates for uploading a PDF and showing results
- update README with instructions to run the prototype

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684e6cddf544832fb9a78031f08592a8